### PR TITLE
INTERLOK-2897 Create the destination using the session first to avoid "no-queue-found"

### DIFF
--- a/src/main/java/com/adaptris/core/amqp/rabbitmq/BasicRabbitMqJmsImplementation.java
+++ b/src/main/java/com/adaptris/core/amqp/rabbitmq/BasicRabbitMqJmsImplementation.java
@@ -1,12 +1,11 @@
 package com.adaptris.core.amqp.rabbitmq;
 
 import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Queue;
 import javax.jms.Topic;
-
 import org.apache.commons.lang3.BooleanUtils;
-
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.jms.JmsActorConfig;
@@ -17,7 +16,6 @@ import com.adaptris.core.jms.VendorImplementationBase;
 import com.rabbitmq.jms.admin.RMQConnectionFactory;
 import com.rabbitmq.jms.admin.RMQDestination;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
 import lombok.Getter;
 import lombok.Setter;
 
@@ -45,11 +43,15 @@ public class BasicRabbitMqJmsImplementation extends UrlVendorImplementation {
    * Force the underlying JMS destination to be interopable with AMQP.
    * <p>
    * Setting this to true changes queue and topic creation to use the
-   * {@code RMQDestination(String,String,String,String)} constructor.
-   * rather than delegating it to the underlying session. This allows interopability with AMQP senders such as
-   * <a href="https://github.com/ruby-amqp/bunny">bunny</a>
-   * JMS Producer/Consumers.
+   * {@code RMQDestination(String,String,String,String)} constructor. rather than delegating it to the
+   * underlying session. This allows interopability with AMQP senders such as
+   * <a href="https://github.com/ruby-amqp/bunny">bunny</a> + JMS Producer/Consumers.
    * </p>
+   * <p>
+   * Note the setting this to be true will still (under the covers) first use the JMS session to
+   * create a standard queue or topic (this has the effect of auto-declaring the required information
+   * within RabbitMQ first. After that it simply returns a {@code RMQDestination} with the specified
+   * name.
    * <p>
    * The default is false if not specified.
    * </p>
@@ -70,13 +72,13 @@ public class BasicRabbitMqJmsImplementation extends UrlVendorImplementation {
 
   @Override
   public boolean connectionEquals(VendorImplementationBase vendorImp) {
-    return (vendorImp instanceof BasicRabbitMqJmsImplementation) && super.connectionEquals(vendorImp);
+    return vendorImp instanceof BasicRabbitMqJmsImplementation && super.connectionEquals(vendorImp);
   }
 
   @Override
   public Queue createQueue(String name, JmsActorConfig c) throws JMSException {
     if (amqpMode()) {
-      return new RMQDestination(name, null, null, name);
+      return createDestination(name, c, true);
     }
     return super.createQueue(name, c);
   }
@@ -84,7 +86,7 @@ public class BasicRabbitMqJmsImplementation extends UrlVendorImplementation {
   @Override
   public Topic createTopic(String name, JmsActorConfig c) throws JMSException {
     if (amqpMode()) {
-      return new RMQDestination(name, null, null, name);
+      return createDestination(name, c, false);
     }
     return super.createTopic(name, c);
   }
@@ -97,5 +99,28 @@ public class BasicRabbitMqJmsImplementation extends UrlVendorImplementation {
 
   public boolean amqpMode() {
     return BooleanUtils.toBooleanDefaultIfNull(getAmqpMode(), false);
+  }
+
+  // This is a workaround for a "no queue found" if the queue hasn't already been created in amqp-mode
+  // Use the session to create the destination first; (which will, since it's a JMS one, it
+  // auto-declares it in RMQSession)
+  // Re-create a RMQ Destination based on what we know.
+  protected RMQDestination createDestination(String name, JmsActorConfig c, boolean isQueue) throws JMSException {
+    Destination d = null;
+    if (isQueue) {
+      d = c.currentSession().createQueue(name);
+    } else {
+      d = c.currentSession().createTopic(name);
+    }
+    return builder().build(name);
+  }
+
+  protected RMQDestinationBuilder builder() {
+    return (name) -> new RMQDestination(name, null, null, name);
+  }
+
+  @FunctionalInterface
+  protected interface RMQDestinationBuilder {
+    RMQDestination build(String name) throws JMSException;
   }
 }

--- a/src/test/java/com/adaptris/core/amqp/rabbitmq/AdvancedRabbitMqImplementationTest.java
+++ b/src/test/java/com/adaptris/core/amqp/rabbitmq/AdvancedRabbitMqImplementationTest.java
@@ -1,10 +1,7 @@
 package com.adaptris.core.amqp.rabbitmq;
 import static org.junit.Assert.assertNotNull;
-
 import javax.jms.JMSException;
-
 import org.junit.Test;
-
 import com.adaptris.core.amqp.rabbitmq.AdvancedRabbitMqJmsImplementation.ConnectionFactoryProperty;
 import com.adaptris.util.KeyValuePair;
 
@@ -40,6 +37,7 @@ public class AdvancedRabbitMqImplementationTest extends BasicRabbitMqImplementat
     mq.getConnectionFactoryProperties().add(new KeyValuePair(ConnectionFactoryProperty.UseDefaultSslContext.name(), "true"));
     mq.getConnectionFactoryProperties().add(new KeyValuePair(ConnectionFactoryProperty.Username.name(), "admin"));
     mq.getConnectionFactoryProperties().add(new KeyValuePair(ConnectionFactoryProperty.VirtualHost.name(), "vhost"));
+    mq.getConnectionFactoryProperties().add(new KeyValuePair(ConnectionFactoryProperty.DeclareReplyToDestination.name(), "false"));
     // This is a property that's not in the enum, and with no setSomethingElse method.
     mq.getConnectionFactoryProperties().add(new KeyValuePair("SomethingElse", "amqp://localhost:5672"));
     // This is a property that's not in the enum, but does exist as a setter.

--- a/src/test/java/com/adaptris/core/amqp/rabbitmq/BasicRabbitMqImplementationTest.java
+++ b/src/test/java/com/adaptris/core/amqp/rabbitmq/BasicRabbitMqImplementationTest.java
@@ -6,16 +6,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.Topic;
-
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.core.jms.JmsActorConfig;
 import com.adaptris.core.jms.activemq.BasicActiveMqImplementation;
 import com.rabbitmq.jms.admin.RMQDestination;
@@ -85,4 +82,5 @@ public class BasicRabbitMqImplementationTest {
     Mockito.when(session.createTopic(any())).thenReturn(topic);
     return config;
   }
+
 }


### PR DESCRIPTION
- Create the destination using the session first; after looking at the underlying RMQSession code, if we do that, then it auto-declares the queue/topic properly
- After using the session to create the queue, create the RMQDestination as normal.
- Refactor to avoid code dupe
- Add DeclareReplyToDestination as part of the ConnectionProperty enum