### PR TITLE
Tooling upgrades + deprecation removal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,25 +33,22 @@ ext {
   nettyVersion="4.1.68.Final"
 }
 
-ext.hasGraphViz = { ->
-//  def app = "dot"
-//  if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-//    app = app + ".exe"
-//  }
-//  return System.getenv("PATH").split(File.pathSeparator).any{
-//    java.nio.file.Paths.get("${it}").resolve(app).toFile().exists()
-//  }
-  return false
-}
+ext.buildDetails = [
+  hostname: { ->
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+      return System.getenv("COMPUTERNAME")
+    }
+    return System.getenv("HOSTNAME")
+  },
 
-ext.gitBranchNameOrTimestamp = { branchName ->
-  if (branchName.equals("HEAD") || branchName.equals("develop") || branchName.startsWith("release")) {
-    return new Date().format('HH:mm:ss z');
-  }
-  return branchName;
-}
+  gitBranchNameOrTimestamp: { branchName ->
+    if (branchName.equals("HEAD") || branchName.equals("develop") || branchName.startsWith("release")) {
+      return new Date().format('HH:mm:ss z');
+    }
+    return branchName;
+  },
 
-ext.buildInfo = { ->
+  buildInfo: { ->
    new ByteArrayOutputStream().withStream { os ->
       exec {
         executable = "git"
@@ -59,10 +56,24 @@ ext.buildInfo = { ->
         standardOutput = os
       }
       def branchName = os.toString().replaceAll("\r", "").replaceAll("\n", "").trim();
-      return gitBranchNameOrTimestamp(branchName);
+      return buildDetails.gitBranchNameOrTimestamp(branchName);
     }
-}
+  },
 
+  // If graphviz is installed via scoop, plantuml doesn't find it because it's not
+  // in its expected "location(s)" it searches for c:\*\graphviz**\dot.exe
+  // so windows we'd expect to have the GRAPHVIZ_DOT env defined 
+  // On Linux we should be able to find it via the path.
+  hasGraphViz: { ->
+    def app = "dot"
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+      app = app + ".exe"
+    }
+    return System.getenv("GRAPHVIZ_DOT") !=null ||  System.getenv("PATH").split(File.pathSeparator).any{
+      java.nio.file.Paths.get("${it}").resolve(app).toFile().exists()
+    }
+  } 
+]
 
 // Disable gradle module generation since we probably don't want
 // xxx.module files in your repository.
@@ -158,7 +169,7 @@ dependencies {
 
 
   annotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion") {changing= true}
-  umlDoclet("nl.talsmasoftware:umldoclet:1.1.4")
+  umlDoclet("nl.talsmasoftware:umldoclet:2.0.14")
 
   testImplementation ('junit:junit:4.13.2')
 
@@ -209,7 +220,7 @@ task generateVersion {
       entry(key: 'artifactId', value: project.name)
       entry(key: 'build.version', value: releaseVersion)
       entry(key: 'build.date', value: new Date().format('yyyy-MM-dd'))
-      entry(key: 'build.info', value: buildInfo())
+      entry(key: 'build.info', value: buildDetails.buildInfo())
     }
   }
 }
@@ -231,7 +242,7 @@ task offlinePackageList(type: Copy) {
 
 javadoc {
   onlyIf {
-    !hasGraphViz()
+    !buildDetails.hasGraphViz()
   }
   configure(options) {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
@@ -272,7 +283,7 @@ task umlJavadoc(type: Javadoc) {
   description 'Build javadocs using plantuml + graphviz + umldoclet, if dot is available'
 
   onlyIf {
-    hasGraphViz()
+    buildDetails.hasGraphViz()
   }
   source = sourceSets.main.extensions.delombokTask
   classpath = project.sourceSets.main.compileClasspath
@@ -281,25 +292,16 @@ task umlJavadoc(type: Javadoc) {
     options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
     taglets = ["com.adaptris.taglet.ConfigTaglet", "com.adaptris.taglet.LicenseTaglet"]
     options.addStringOption "tagletpath", configurations.javadoc.asPath
-    options.addStringOption('Xdoclint:none', '-quiet')
+    options.addStringOption "Xdoclint:none", "-quiet"
     options.addBooleanOption "-no-module-directories", true
     options.docletpath = configurations.umlDoclet.files.asType(List)
     options.doclet = "nl.talsmasoftware.umldoclet.UMLDoclet"
-    options.addStringOption "umlBasePath", destinationDir.getCanonicalPath()
+    // Create class & package use pages
+    options.addStringOption "use"
     options.addStringOption "umlImageFormat", "SVG"
-    options.addStringOption "umlExcludedReferences", "java.lang.Exception,java.lang.Object,java.lang.Enum"
-    options.addStringOption "umlIncludePrivateClasses","false"
-    options.addStringOption "umlIncludePackagePrivateClasses","false"
-    options.addStringOption "umlIncludeProtectedClasses","false"
-    options.addStringOption "umlIncludeAbstractSuperclassMethods","false"
-    options.addStringOption "umlIncludeConstructors","false"
-    options.addStringOption "umlIncludePublicFields","false"
-    options.addStringOption "umlIncludePackagePrivateFields","false"
-    options.addStringOption "umlIncludeProtectedFields", "false"
-    options.addStringOption "umlIncludeDeprecatedClasses", "false"
-    options.addStringOption "umlIncludePrivateInnerClasses", "false"
-    options.addStringOption "umlIncludePackagePrivateInnerClasses", "false"
-    options.addStringOption "umlIncludeProtectedInnerClasses","false"
+    options.addStringOption "umlExcludedTypeReferences", "java.lang.Exception,java.lang.Object,java.lang.Enum,java.lang.annotation.Annotation"
+    options.addStringOption "umlJavaBeanPropertiesAsFields"
+    options.addBooleanOption "failOnCyclicPackageDependencies", false
     title= componentName
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ ext {
   activeMqVersion= '5.16.3'
   mockitoVersion = '3.12.4'
   nettyVersion="4.1.68.Final"
-  log4j2Version = '2.14.1'
 }
 
 ext.hasGraphViz = { ->
@@ -172,10 +171,6 @@ dependencies {
   testImplementation("org.apache.activemq:activemq-amqp:$activeMqVersion")
   testImplementation("org.apache.activemq.protobuf:activemq-protobuf:1.1")
   testImplementation("org.apache.geronimo.specs:geronimo-jms_1.1_spec:1.1.1")
-  // INTERLOK-3233 reveals that we have a duff test class!
-  // testImplementation ("org.apache.logging.log4j:log4j-core:$log4j2Version")
-  // testImplementation ("org.apache.logging.log4j:log4j-api:$log4j2Version")
-  // testImplementation ("org.apache.logging.log4j:log4j-1.2-api:$log4j2Version")
 
   javadoc("com.adaptris:interlok-core-apt:$interlokCoreVersion") { changing= true}
 

--- a/build.gradle
+++ b/build.gradle
@@ -173,9 +173,9 @@ dependencies {
   testImplementation("org.apache.activemq.protobuf:activemq-protobuf:1.1")
   testImplementation("org.apache.geronimo.specs:geronimo-jms_1.1_spec:1.1.1")
   // INTERLOK-3233 reveals that we have a duff test class!
-  testImplementation ("org.apache.logging.log4j:log4j-core:$log4j2Version")
-  testImplementation ("org.apache.logging.log4j:log4j-api:$log4j2Version")
-  testImplementation ("org.apache.logging.log4j:log4j-1.2-api:$log4j2Version")
+  // testImplementation ("org.apache.logging.log4j:log4j-core:$log4j2Version")
+  // testImplementation ("org.apache.logging.log4j:log4j-api:$log4j2Version")
+  // testImplementation ("org.apache.logging.log4j:log4j-1.2-api:$log4j2Version")
 
   javadoc("com.adaptris:interlok-core-apt:$interlokCoreVersion") { changing= true}
 

--- a/src/test/java/com/adaptris/core/amqp/qpid/BasicQpidImplementationTest.java
+++ b/src/test/java/com/adaptris/core/amqp/qpid/BasicQpidImplementationTest.java
@@ -9,19 +9,14 @@ import javax.jms.JMSException;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.adaptris.core.BaseCase;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.activemq.BasicActiveMqImplementation;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
 import com.adaptris.util.TimeInterval;
 
 public class BasicQpidImplementationTest extends BaseCase {
 
   private static Logger log = LoggerFactory.getLogger(BasicQpidImplementationTest.class);
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
   
   @Test
   public void testConnectionFactory() throws Exception {

--- a/src/test/java/com/adaptris/core/amqp/qpid/BasicQpidJmsImplementationTest.java
+++ b/src/test/java/com/adaptris/core/amqp/qpid/BasicQpidJmsImplementationTest.java
@@ -9,44 +9,38 @@ import javax.jms.JMSException;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.adaptris.core.BaseCase;
 import com.adaptris.core.jms.JmsConnection;
 import com.adaptris.core.jms.activemq.BasicActiveMqImplementation;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
 import com.adaptris.util.TimeInterval;
 
 public class BasicQpidJmsImplementationTest extends BaseCase {
 
   private static Logger log = LoggerFactory.getLogger(BasicQpidJmsImplementationTest.class);
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-
 
   // Can't actually test against a real ActiveMQ broker,
   // 5.9.0 "hangs"; 5.11.1 fails with a stupid NoMethodError
-  // @Test
-  // public void testConnectionFactory() throws Exception {
-  // EmbeddedAMQP broker = new EmbeddedAMQP();
-  // broker.start();
-  // JmsConnection connection = configureForTests(new JmsConnection(), broker);
-  // try {
-  // start(connection);
-  // assertNotNull(connection.currentConnection());
-  // assertTrue(connection.currentConnection() instanceof javax.jms.Connection);
-  // assertNotNull(connection.currentConnection().getMetaData());
-  // }
-  // finally {
-  // stop(connection);
-  // broker.destroy();
-  // }
-  // }
-
   @Test
   public void testConnectionFactory() throws Exception {
-    BasicQpidJmsImplementation vendor = createVendorImpl("amqp://localhost:5672");
-    assertNotNull(vendor.createConnectionFactory());
+    EmbeddedAMQP broker = new EmbeddedAMQP();
+    broker.start();
+    JmsConnection connection = configureForTests(new JmsConnection(), broker);
+    try {
+      start(connection);
+      assertNotNull(connection.currentConnection());
+      assertTrue(connection.currentConnection() instanceof javax.jms.Connection);
+      assertNotNull(connection.currentConnection().getMetaData());
+    } finally {
+      stop(connection);
+      broker.destroy();
+    }
   }
+
+//  @Test
+//  public void testConnectionFactory() throws Exception {
+//    BasicQpidJmsImplementation vendor = createVendorImpl("amqp://localhost:5672");
+//    assertNotNull(vendor.createConnectionFactory());
+//  }
 
   @Test
   public void testConnectionFactory_withException() throws Exception {

--- a/src/test/java/com/adaptris/core/amqp/qpid/EmbeddedAMQP.java
+++ b/src/test/java/com/adaptris/core/amqp/qpid/EmbeddedAMQP.java
@@ -1,24 +1,22 @@
 package com.adaptris.core.amqp.qpid;
 
-import static com.adaptris.core.PortManager.release;
-
+import static com.adaptris.interlok.junit.scaffolding.util.PortManager.release;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.store.memory.MemoryPersistenceAdapter;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
-
-import com.adaptris.core.PortManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.adaptris.interlok.junit.scaffolding.util.PortManager;
 import com.adaptris.util.SafeGuidGenerator;
 
 public class EmbeddedAMQP {
 
   private static final String AMQP_URL_PREFIX = "amqp://0.0.0.0:";
   private static final String OPENWIRE_URL_PREFIX = "tcp://localhost:";
-  private static Logger log = Logger.getLogger(EmbeddedAMQP.class);
+  private static Logger log = LoggerFactory.getLogger(EmbeddedAMQP.class);
   private BrokerService broker = null;
   private String brokerName;
   private File brokerDataDir;

--- a/src/test/java/com/adaptris/core/amqp/qpid/amqp_0_10/StandardQpidImplementationTest.java
+++ b/src/test/java/com/adaptris/core/amqp/qpid/amqp_0_10/StandardQpidImplementationTest.java
@@ -8,17 +8,13 @@ import javax.jms.JMSException;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.adaptris.core.BaseCase;
 import com.adaptris.core.amqp.qpid.BasicQpidImplementationTest;
 import com.adaptris.core.jms.activemq.BasicActiveMqImplementation;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
 
 public class StandardQpidImplementationTest extends BaseCase {
 
   private static Logger log = LoggerFactory.getLogger(BasicQpidImplementationTest.class);
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 
   @Test
   public void testConnectionFactory() throws Exception {

--- a/src/test/java/com/adaptris/core/amqp/rabbitmq/AdvancedRabbitMqImplementationTest.java
+++ b/src/test/java/com/adaptris/core/amqp/rabbitmq/AdvancedRabbitMqImplementationTest.java
@@ -17,7 +17,6 @@ public class AdvancedRabbitMqImplementationTest extends BasicRabbitMqImplementat
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void testApplyConnectionFactoryProperties() throws Exception {
     AdvancedRabbitMqJmsImplementation mq = new AdvancedRabbitMqJmsImplementation();
     mq.setBrokerUrl("amqp://localhost:5672");
@@ -55,7 +54,6 @@ public class AdvancedRabbitMqImplementationTest extends BasicRabbitMqImplementat
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void testApplyConnectionFactoryProperties_UseSsl() throws Exception {
     AdvancedRabbitMqJmsImplementation mq = new AdvancedRabbitMqJmsImplementation();
     mq.setBrokerUrl("amqp://localhost:5672");


### PR DESCRIPTION
## Motivation

Tidy up the AMQP codebase so that I can review and work on it.

## Modification

- Remove dependency on log4j2 in test impl
- Remove use of deprecated classes
- Restore test that relies on AMQP broker since this now works in 5.16.3 ActiveMQ.
- Bump umldoclet to 2.0.14 and enable it for javadocs if graphviz is available.

If graphviz is installed via scoop, plantuml doesn't find it because it's not in its expected "location(s)" it searches for c:\*\graphviz**\dot.exe -> https://plantuml.com/graphviz-dot
Thus we check the additional environment variable GRAPHVIZ_DOT as well, making dot availability subject to `if (getenv(GRAPHVIZ_DOT) != null) || (dot.exe found on the path) `

This fixes one of the INTERLOK tickets around umldoclet  + java11

## PR Checklist

- [x] been self-reviewed.
- [x] Added unit tests or modified existing tests to cover new code paths

## Result

Javadocs should now have pretty UML

## Testing

- `./gradlew test` still works
- `./gradlew javadoc` builds w/o SVG files

### Test Graphviz

- On WSL, just `sudo apt-get install graphviz` + `./gradlew clean javadoc` should trigger umlJavadoc and create at least one svg file (You can eyeball package-dependencies.svg at least)
- On Windows, install it via your preferred mechanism (`scoop install graphviz`)
   - Administrator Prompt - cd graphviz && dot -c  // to register the plugins
   - Set the GRAPHVIZ_DOT environment variable to point to dot.exe
   - `./gradlew clean javadoc` should trigger umljavadoc and create at least one SVG file.

