### PR TITLE
Amqp1.0

### DIFF
--- a/interlok-artemis-amqp/README.md
+++ b/interlok-artemis-amqp/README.md
@@ -8,7 +8,7 @@
 [![Known Vulnerabilities](https://snyk.io/test/github/adaptris/interlok-amqp/badge.svg?targetFile=build.gradle)](https://snyk.io/test/github/adaptris/interlok-amqp?targetFile=build.gradle)
 [![Closed PRs](https://img.shields.io/github/issues-pr-closed/adaptris/interlok-amqp)](https://github.com/adaptris/interlok-amqp/pulls?q=is%3Apr+is%3Aclosed)
 
-Interlok with AMQP 1.0/0.9 + RabbitMQ
+Interlok with AMQP 1.0 + Apache Artemis
 
 !Note that error messages can be quite confusing.
 

--- a/interlok-artemis-amqp/README.md
+++ b/interlok-artemis-amqp/README.md
@@ -1,0 +1,19 @@
+# interlok-amqp
+
+[![GitHub tag](https://img.shields.io/github/tag/adaptris/interlok-amqp.svg)](https://github.com/adaptris/interlok-amqp/tags)
+[![license](https://img.shields.io/github/license/adaptris/interlok-amqp.svg)](https://github.com/adaptris/interlok-amqp/blob/develop/LICENSE)
+[![Actions Status](https://github.com/adaptris/interlok-amqp/actions/workflows/gradle-publish.yml/badge.svg)](https://github.com/adaptris/interlok-amqp/actions)
+[![codecov](https://codecov.io/gh/adaptris/interlok-amqp/branch/develop/graph/badge.svg)](https://codecov.io/gh/adaptris/interlok-amqp)
+[![CodeQL](https://github.com/adaptris/interlok-amqp/workflows/CodeQL/badge.svg)](https://github.com/adaptris/interlok-amqp/security/code-scanning)
+[![Known Vulnerabilities](https://snyk.io/test/github/adaptris/interlok-amqp/badge.svg?targetFile=build.gradle)](https://snyk.io/test/github/adaptris/interlok-amqp?targetFile=build.gradle)
+[![Closed PRs](https://img.shields.io/github/issues-pr-closed/adaptris/interlok-amqp)](https://github.com/adaptris/interlok-amqp/pulls?q=is%3Apr+is%3Aclosed)
+
+Interlok with AMQP 1.0/0.9 + RabbitMQ
+
+!Note that error messages can be quite confusing.
+
+For example, during testing we forgot to create the queue on the host broker and received the following when attempting to publish
+
+```
+SMF AD ack response error [condition = amqp:not-allowed]
+```

--- a/interlok-artemis-amqp/build.gradle
+++ b/interlok-artemis-amqp/build.gradle
@@ -1,0 +1,95 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.apache.tools.ant.filters.*
+
+ext {
+  componentName='Interlok Messaging/AMQP'
+  componentDesc='Treating a AMQP 0.9.0/1.0 Provider as a JMS via Apache QPID'
+  delombokTargetDir = new File("${project.projectDir}/src/main/generated")
+  activeMqVersion= '5.17.2'
+  nettyVersion="4.1.97.Final"
+}
+
+dependencies {
+   
+  
+  implementation ("org.apache.activemq:artemis-jms-client:2.30.0")
+  implementation ("org.apache.qpid:qpid-jms-client:1.10.0")
+
+}
+
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+  classifier = 'javadoc'
+  from javadoc.destinationDir
+}
+
+task examplesJar(type: Jar, dependsOn: test) {
+  classifier = 'examples'
+  from new File(buildDir, '/examples')
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+  classifier = 'sources'
+  from sourceSets.main.extensions.delombokTask
+}
+
+jar {
+  manifest {
+    attributes("Built-By": System.getProperty('user.name'),
+              "Build-Jdk": System.getProperty('java.version'),
+              "Implementation-Title": componentName,
+              "Implementation-Version": project.version,
+              "Implementation-Vendor-Id": project.group,
+              "Implementation-Vendor": organizationName)
+  }
+}
+
+artifacts {
+  archives javadocJar
+  archives examplesJar
+  archives sourcesJar
+}
+
+publishing {
+  publications {
+    mavenJava(MavenPublication) {
+      from components.java
+
+      artifact javadocJar { classifier "javadoc" }
+      artifact examplesJar { classifier "examples" }
+      artifact sourcesJar { classifier "sources" }
+      pom.withXml {
+        asNode().appendNode("name", componentName)
+        asNode().appendNode("description", componentDesc)
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/")
+        def properties = asNode().appendNode("properties")
+        properties.appendNode("target", "3.8.0+")
+        properties.appendNode("tags", "amqp,jms")
+        properties.appendNode("license", "false")
+        properties.appendNode("externalUrl", "https://www.amqp.org/")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-amqp")
+      }
+    }
+  }
+  repositories {
+    maven {
+      credentials {
+        username repoUsername
+        password repoPassword
+      }
+      url mavenPublishUrl
+    }
+  }
+}
+
+
+delombok {
+  target = delombokTargetDir
+}
+
+task deleteGeneratedFiles(type: Delete) {
+  delete file(testResourcesDir() + "/unit-tests.properties"), file(testResourcesDir() + "/unit-tests.properties.resolved"), delombokTargetDir
+}
+
+clean.dependsOn deleteGeneratedFiles
+processTestResources.dependsOn copyUnitTestProperties

--- a/interlok-artemis-amqp/src/main/java/com/adaptris/core/amqp/artemis/BasicArtemisAMQPImplementation.java
+++ b/interlok-artemis-amqp/src/main/java/com/adaptris/core/amqp/artemis/BasicArtemisAMQPImplementation.java
@@ -1,0 +1,55 @@
+package com.adaptris.core.amqp.artemis;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+
+import org.apache.qpid.jms.JmsConnectionFactory;
+
+import com.adaptris.core.jms.JmsConnection;
+import com.adaptris.core.jms.UrlVendorImplementation;
+import com.adaptris.core.jms.VendorImplementation;
+import com.adaptris.core.jms.VendorImplementationBase;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * AMQP 1.0 implementation of {@link VendorImplementation} using Apache Artemis.
+ * 
+ * <p>
+ * Everything required to configure the connection needs to be specified on the URL. If you
+ * configure a username and password on the wrapping {@link JmsConnection} in which case
+ * {@link ConnectionFactory#createConnection(String, String)} is used when creating the connection
+ * otherwise {@link ConnectionFactory#createConnection()} will be used.
+ * </p>
+ * <p>
+ * This vendor implementation is suitable for use with Azure AMQP. If you are using a topic consumer then it must be a durable
+ * subscriber where the subscriptionID is the same as the subscription created in the Azure portal; the topic name should be
+ * {@code [topic-name]/subscriptions/[subscriptionID]}. Your mileage may vary but during testing this was the the only destination
+ * configuration that seemed to work; the documentation suggests that this might actually pretending to be a {@code queue}.
+ * </p>
+ * 
+ * @config artemis-basic-amqp-implementation
+ */
+@XStreamAlias("artemis-basic-amqp-implementation")
+public class BasicArtemisAMQPImplementation extends UrlVendorImplementation {
+
+  ConnectionFactory createArtemisAMQPConnectionFactory() throws JMSException {
+    ConnectionFactory cf;
+    try {
+      cf = new JmsConnectionFactory(getBrokerUrl());
+    } catch (Exception e) {
+      throw new JMSException(e.getMessage());
+    }
+    return cf;
+  }
+
+  @Override
+  public ConnectionFactory createConnectionFactory() throws JMSException {
+    return createArtemisAMQPConnectionFactory();
+  }
+
+  @Override
+  public boolean connectionEquals(VendorImplementationBase vendorImp) {
+    return vendorImp instanceof BasicArtemisAMQPImplementation && super.connectionEquals(vendorImp);
+  }
+
+}

--- a/interlok-artemis-amqp/src/main/java/com/adaptris/core/amqp/artemis/BasicArtemisAMQPImplementation.java
+++ b/interlok-artemis-amqp/src/main/java/com/adaptris/core/amqp/artemis/BasicArtemisAMQPImplementation.java
@@ -12,7 +12,7 @@ import com.adaptris.core.jms.VendorImplementationBase;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * AMQP 1.0 implementation of {@link VendorImplementation} using Apache Artemis.
+ * AMQP 1.0 implementation of {@link VendorImplementation} using Apache Artemis and QPid.
  * 
  * <p>
  * Everything required to configure the connection needs to be specified on the URL. If you
@@ -21,10 +21,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * otherwise {@link ConnectionFactory#createConnection()} will be used.
  * </p>
  * <p>
- * This vendor implementation is suitable for use with Azure AMQP. If you are using a topic consumer then it must be a durable
- * subscriber where the subscriptionID is the same as the subscription created in the Azure portal; the topic name should be
- * {@code [topic-name]/subscriptions/[subscriptionID]}. Your mileage may vary but during testing this was the the only destination
- * configuration that seemed to work; the documentation suggests that this might actually pretending to be a {@code queue}.
+ * This vendor implementation is suitable for use with Solace AMQP.
  * </p>
  * 
  * @config artemis-basic-amqp-implementation

--- a/interlok-artemis-amqp/src/test/java/com/adaptris/core/amqp/artemis/BasicArtemisAMQPImplementationTest.java
+++ b/interlok-artemis-amqp/src/test/java/com/adaptris/core/amqp/artemis/BasicArtemisAMQPImplementationTest.java
@@ -1,0 +1,61 @@
+package com.adaptris.core.amqp.artemis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import javax.jms.ConnectionFactory;
+
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.adaptris.core.jms.activemq.BasicActiveMqImplementation;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
+
+public class BasicArtemisAMQPImplementationTest  extends BaseCase {
+
+  private BasicArtemisAMQPImplementation impl;
+  
+  @BeforeEach
+  public void setUp() throws Exception {
+    impl = new BasicArtemisAMQPImplementation();
+  }
+  
+  @Test
+  public void testConnectionFactory() throws Exception {
+    impl.setBrokerUrl("amqp://localhost:5672");
+    ConnectionFactory connFact = impl.createConnectionFactory();
+    
+    assertTrue(connFact instanceof JmsConnectionFactory);
+    assertEquals("amqp://localhost:5672", ((JmsConnectionFactory) connFact).getRemoteURI().toString());
+  }
+  
+  @Test
+  public void testConnectionFactoryFails() throws Exception {
+    try {
+      impl.createConnectionFactory();
+      fail("No URL provided, should fail.");
+    } catch (Exception ex) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testConnectionEquals() throws Exception {
+    BasicArtemisAMQPImplementation vendor1 = createVendorImpl("amqp://localhost:5672");
+    BasicArtemisAMQPImplementation vendor2 = createVendorImpl("amqp://localhost:5672");
+    
+    assertTrue(vendor1.connectionEquals(vendor2));
+    assertFalse(vendor1.connectionEquals(createVendorImpl("amqp://localhost:5673")));
+    assertFalse(vendor1.connectionEquals(new BasicActiveMqImplementation()));
+  }
+
+  protected BasicArtemisAMQPImplementation createVendorImpl(String brokerUrl) {
+    BasicArtemisAMQPImplementation mq = new BasicArtemisAMQPImplementation();
+    mq.setBrokerUrl(brokerUrl);
+    return mq;
+  }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'interlok-amqp-parent'
 include 'interlok-amqp'
 include 'interlok-rabbitmq'
+include 'interlok-artemis-amqp'


### PR DESCRIPTION
## Motivation

We currently cannot test our AMQP solutions against Solace.

## Modification

We're now using Apache Artemis AMQP client to perform AMQP 1.0 connections.
Essentially we simply added a new JMS vendor implementation which simply creates the AMQP ConnectionFactory.

## Result

We can now use AMQP 1.0 with Solace.
we will still use the JMS connection / consumer / producer components, but with the new amqp-artemis vendor impl.

